### PR TITLE
Warnings after done_testing() should not cause cause test failures

### DIFF
--- a/lib/Test2/Plugin/NoWarnings.pm
+++ b/lib/Test2/Plugin/NoWarnings.pm
@@ -6,7 +6,7 @@ use warnings;
 our $VERSION = '0.09';
 
 use Test2 1.302096;
-use Test2::API qw( context_do );
+use Test2::API qw( context_do test2_is_testing_done );
 use Test2::Event::Warning;
 
 my $echo = 0;
@@ -21,17 +21,21 @@ sub import {
 my $_orig_warn_handler = $SIG{__WARN__};
 ## no critic (Variables::RequireLocalizedPunctuationVars)
 $SIG{__WARN__} = sub {
-    my $w = $_[0];
-    $w =~ s/\n+$//g;
 
-    context_do {
-        my $ctx = shift;
-        $ctx->send_event(
-            'Warning',
-            warning => "Unexpected warning: $w",
-        );
+    unless ( test2_is_testing_done() ) {
+        my $w = $_[0];
+        $w =~ s/\n+$//g;
+
+        context_do {
+            my $ctx = shift;
+            $ctx->send_event(
+                'Warning',
+                warning => "Unexpected warning: $w",
+            );
+        }
+        $_[0];
+
     }
-    $_[0];
 
     return unless $echo;
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -73,3 +73,6 @@ use Test2::Plugin::NoWarnings;
 }
 
 done_testing();
+
+# Make sure we respect done_testing()
+warn "This should not cause the test to fail!\n";


### PR DESCRIPTION
To demonstrate the problem, I simply plumb in a call to `warn` after done_testing(), which causes a test failure for the existing code; while this is consistent with the intent of the plugin (if maybe a little above-and-beyond), it's a test failure because of a bad plan, which suggests that it's not the right way to handle the situation.

[The `Test2::API` documentation](https://metacpan.org/pod/Test2::API#$bool-=-test2_is_testing_done()) happens to address exactly this scenario, so we borrow their solution.

Since all other behavior the `$SIG{__WARN__}` handler displays continues to be appropriate, we simply avoid the `context_do` call if testing has completed.

This resolves issue #2.